### PR TITLE
Bugfix created directory path may include white space

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -35,9 +35,27 @@ test('createDirName() returns workspaceName', async () => {
   await expect(actual).toEqual(workspaceName)
 })
 
+test('createDirName() returns escaped workspaceName', async () => {
+  const workspaceName = 'test dir'
+  const actual = createDirName(contextMock, workspaceName)
+  await expect(actual).toEqual('test%20dir')
+})
+
 test('createDirName() returns default name', async () => {
   const actual = createDirName(contextMock, "")
   await expect(actual).toEqual(`${workflowName}-${jobName}`)
+})
+
+test('createDirName() returns escaped default name', async () => {
+  const workflowName = 'test'
+  const jobName = 'test Job'
+  const contextMock = {
+    workflow: `./.github/workflows/${workflowName}.yml`,
+    job: jobName
+  } as unknown as Context
+
+  const actual = createDirName(contextMock, "")
+  await expect(actual).toEqual(`${workflowName}-test%20Job`)
 })
 
 test('replaceWorkspace() with workspaceName', async () => {

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -18,9 +18,13 @@ function getRunnerWorkspacePath (): string {
   return process.env.RUNNER_WORKSPACE
 }
 
+function escapeDirName (rawDirName: string): string {
+  return encodeURI(rawDirName)
+}
+
 export function createDirName (context: Context, workspaceName: string): string {
   core.debug(`workspaceName: ${workspaceName}`)
-  if (workspaceName !== '') return workspaceName
+  if (workspaceName !== '') return escapeDirName(workspaceName)
 
   const workflowYaml = context.workflow
   core.debug(`workflowYaml: ${workflowYaml}`)
@@ -28,7 +32,7 @@ export function createDirName (context: Context, workspaceName: string): string 
   const yamlExtName = path.extname(workflowYaml)
   const workflowYamlBaseName = path.basename(workflowYaml, yamlExtName)
 
-  return `${workflowYamlBaseName}-${context.job}`
+  return escapeDirName(`${workflowYamlBaseName}-${context.job}`)
 }
 
 export async function replaceWorkspace (context: Context, workspaceName: string): Promise<void> {


### PR DESCRIPTION
Previously, created directory path may include white space when workflow job `name:` include white space string.